### PR TITLE
Compatibility fixes for WooCommerce 3.0+

### DIFF
--- a/woocommerce-custom-availability.php
+++ b/woocommerce-custom-availability.php
@@ -157,7 +157,7 @@ class WooCommerce_Custom_Availability {
    * @param WC_Product $product
    */
   public function custom_availability( $availability, $product ) {
-    $product_id = isset( $product->variation_id ) ? $product->variation_id : $product->id;
+    $product_id = $product->get_id();
     $custom_availability = get_post_meta( $product_id, '_custom_availability', true );
 
     if ( ! empty( $custom_availability ) ) {


### PR DESCRIPTION
WP throws a notice: variation_id was called incorrectly. Product properties should not be accessed directly.
WC_Product::get_variation_id is depricated, so better to use WC_Product::get_id(). It will always be the variation ID if the item is a variation.